### PR TITLE
PDFRenderer will now render PDFs with basic strokes.

### DIFF
--- a/PdfBoxAndroid/src/org/apache/pdfbox/contentstream/operator/state/SetLineCapStyle.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/contentstream/operator/state/SetLineCapStyle.java
@@ -1,10 +1,13 @@
 package org.apache.pdfbox.contentstream.operator.state;
 
+import android.graphics.Paint;
+
 import java.util.List;
 
 import org.apache.pdfbox.contentstream.operator.Operator;
 import org.apache.pdfbox.contentstream.operator.OperatorProcessor;
 import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSNumber;
 
 import java.io.IOException;
@@ -19,7 +22,21 @@ public class SetLineCapStyle extends OperatorProcessor
     @Override
     public void process(Operator operator, List<COSBase> arguments) throws IOException
     {
-        int lineCapStyle = ((COSNumber)arguments.get( 0 )).intValue();
+        Paint.Cap lineCapStyle;
+        switch(((COSNumber)arguments.get( 0 )).intValue())  {
+            case 0:
+                lineCapStyle = Paint.Cap.BUTT;
+                break;
+            case 1:
+                lineCapStyle = Paint.Cap.ROUND;
+                break;
+            case 2:
+                lineCapStyle = Paint.Cap.SQUARE;
+                break;
+            default:
+                lineCapStyle = null;
+        }
+
         context.getGraphicsState().setLineCap( lineCapStyle );
     }
 

--- a/PdfBoxAndroid/src/org/apache/pdfbox/contentstream/operator/state/SetLineJoinStyle.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/contentstream/operator/state/SetLineJoinStyle.java
@@ -1,5 +1,7 @@
 package org.apache.pdfbox.contentstream.operator.state;
 
+import android.graphics.Paint;
+
 import java.util.List;
 
 import org.apache.pdfbox.contentstream.operator.Operator;
@@ -19,7 +21,21 @@ public class SetLineJoinStyle extends OperatorProcessor
     @Override
     public void process(Operator operator, List<COSBase> arguments) throws IOException
     {
-        int lineJoinStyle = ((COSNumber)arguments.get( 0 )).intValue();
+        Paint.Join lineJoinStyle;
+        switch(((COSNumber)arguments.get( 0 )).intValue())  {
+            case 0:
+                lineJoinStyle = Paint.Join.MITER;
+                break;
+            case 1:
+                lineJoinStyle = Paint.Join.ROUND;
+                break;
+            case 2:
+                lineJoinStyle = Paint.Join.BEVEL;
+                break;
+            default:
+                lineJoinStyle = null;
+        }
+
         context.getGraphicsState().setLineJoin( lineJoinStyle );
     }
 

--- a/PdfBoxAndroid/src/org/apache/pdfbox/pdmodel/graphics/state/PDExtendedGraphicsState.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/pdmodel/graphics/state/PDExtendedGraphicsState.java
@@ -1,5 +1,7 @@
 package org.apache.pdfbox.pdmodel.graphics.state;
 
+import android.graphics.Paint;
+
 import java.io.IOException;
 
 import org.apache.pdfbox.cos.COSArray;
@@ -173,9 +175,18 @@ public class PDExtendedGraphicsState implements COSObjectable
 	 *
 	 * @return null or the LC value of the dictionary.
 	 */
-	public int getLineCapStyle()
+	public Paint.Cap getLineCapStyle()
 	{
-		return dict.getInt( COSName.LC );
+        switch(dict.getInt( COSName.LC ))  {
+            case 0:
+                return Paint.Cap.BUTT;
+            case 1:
+                return Paint.Cap.ROUND;
+            case 2:
+                return Paint.Cap.SQUARE;
+            default:
+                return null;
+        }
 	}
 
 	/**
@@ -193,9 +204,18 @@ public class PDExtendedGraphicsState implements COSObjectable
 	 *
 	 * @return null or the LJ value in the dictionary.
 	 */
-	public int getLineJoinStyle()
+	public Paint.Join getLineJoinStyle()
 	{
-		return dict.getInt( COSName.LJ );
+        switch(dict.getInt( COSName.LJ ))  {
+            case 0:
+                return Paint.Join.MITER;
+            case 1:
+                return Paint.Join.ROUND;
+            case 2:
+                return Paint.Join.BEVEL;
+            default:
+                return null;
+        }
 	}
 
 	/**

--- a/PdfBoxAndroid/src/org/apache/pdfbox/pdmodel/graphics/state/PDGraphicsState.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/pdmodel/graphics/state/PDGraphicsState.java
@@ -1,5 +1,7 @@
 package org.apache.pdfbox.pdmodel.graphics.state;
 
+import android.graphics.Paint;
+
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.PDLineDashPattern;
 import org.apache.pdfbox.pdmodel.graphics.blend.BlendMode;
@@ -21,8 +23,8 @@ public class PDGraphicsState implements Cloneable
 //    private PDColorSpace nonStrokingColorSpace = PDDeviceGray.INSTANCE;TODO
     private PDTextState textState = new PDTextState();
     private float lineWidth = 1;
-    private int lineCap = 0; // BUTT, ROUND, SQUARE
-    private int lineJoin = 0; // MITER, ROUND, BEZEL
+    private Paint.Cap lineCap;
+    private Paint.Join lineJoin;
     private float miterLimit = 10;
     private PDLineDashPattern lineDashPattern = new PDLineDashPattern();
     private RenderingIntent renderingIntent;
@@ -97,7 +99,7 @@ public class PDGraphicsState implements Cloneable
      *
      * @return The current line cap.
      */
-    public int getLineCap()
+    public Paint.Cap getLineCap()
     {
         return lineCap;
     }
@@ -107,7 +109,7 @@ public class PDGraphicsState implements Cloneable
      *
      * @param value The current line cap.
      */
-    public void setLineCap(int value)
+    public void setLineCap(Paint.Cap value)
     {
         lineCap = value;
     }
@@ -117,7 +119,7 @@ public class PDGraphicsState implements Cloneable
      *
      * @return The current line join value.
      */
-    public int getLineJoin()
+    public Paint.Join getLineJoin()
     {
         return lineJoin;
     }
@@ -127,7 +129,7 @@ public class PDGraphicsState implements Cloneable
      *
      * @param value The current line join
      */
-    public void setLineJoin(int value)
+    public void setLineJoin(Paint.Join value)
     {
         lineJoin = value;
     }

--- a/PdfBoxAndroid/src/org/apache/pdfbox/rendering/PDFRenderer.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/rendering/PDFRenderer.java
@@ -15,7 +15,7 @@ import android.graphics.Paint;
  * Renders a PDF document to an AWT BufferedImage.
  * This class may be overridden in order to perform custom rendering.
  * @author John Hewson
- * @author Andreas Lehmkühler
+ * @author Andreas LehmkÃ¼hler
  *
  */
 public class PDFRenderer
@@ -40,17 +40,18 @@ public class PDFRenderer
 	 */
 	public Bitmap renderImage(int pageIndex) throws IOException
 	{
-		return renderImage(pageIndex, 1);
+		return renderImage(pageIndex, 1, Bitmap.Config.ARGB_8888);
 	}
 	
 	/**
 	 * Returns the given page as an RGB image at the given scale.
 	 * @param pageIndex the zero-based index of the page to be converted
 	 * @param scale the scaling factor, where 1 = 72 DPI
+     * @param config the bitmap config to create
 	 * @return the rendered page image
 	 * @throws IOException if the PDF cannot be read
 	 */
-	public Bitmap renderImage(int pageIndex, float scale) throws IOException
+	public Bitmap renderImage(int pageIndex, float scale, Bitmap.Config config) throws IOException
 	{
 		PDPage page = document.getPage(pageIndex);
 
@@ -65,26 +66,25 @@ public class PDFRenderer
         Bitmap image;
         if (rotationAngle == 90 || rotationAngle == 270)
         {
-            image = Bitmap.createBitmap(heightPx, widthPx, Bitmap.Config.RGB_565);
+            image = Bitmap.createBitmap(heightPx, widthPx, config);
         }
         else
         {
-            image = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.RGB_565);
+            image = Bitmap.createBitmap(widthPx, heightPx, config);
         }
 
         // use a transparent background if the imageType supports alpha
-//        Graphics2D g = image.createGraphics();
         Paint paint = new Paint();
         Canvas canvas = new Canvas(image);
-//        if (imageType != Bitmap.Config.ARGB_8888)
-//        {
+        if (config != Bitmap.Config.ARGB_8888)
+        {
             paint.setColor(Color.WHITE);
             paint.setStyle(Paint.Style.FILL);
             canvas.drawRect(0, 0, image.getWidth(), image.getHeight(), paint);
-//        }
+            paint.reset();
+        }
 
         renderPage(page, paint, canvas, image.getWidth(), image.getHeight(), scale, scale);
-//        g.dispose();
 
         return image;
 	}
@@ -93,8 +93,6 @@ public class PDFRenderer
     private void renderPage(PDPage page, Paint paint, Canvas canvas, int width, int height, float scaleX,
                             float scaleY) throws IOException
     {
-//        graphics.clearRect(0, 0, width, height);
-
         canvas.scale(scaleX, scaleY);
         // TODO should we be passing the scale to PageDrawer rather than messing with Graphics?
 

--- a/PdfBoxAndroid/src/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/PdfBoxAndroid/src/org/apache/pdfbox/rendering/PageDrawer.java
@@ -98,10 +98,12 @@ public final class PageDrawer extends PDFGraphicsStreamEngine
     }
 	
 	/**
-	 * 
-	 * @param g
-	 * @param pageSize
-	 * @throws IOException
+	 * Draws the page to the requested canvas.
+     *
+     * @param p The paint.
+	 * @param c The canvas to draw onto.
+	 * @param pageSize The size of the page to draw.
+	 * @throws IOException If there is an IO error while drawing the page.
 	 */
 	public void drawPage(Paint p, Canvas c, PDRectangle pageSize) throws IOException
 	{
@@ -117,7 +119,8 @@ public final class PageDrawer extends PDFGraphicsStreamEngine
 		
 		paint.setStrokeCap(Paint.Cap.BUTT);
 		paint.setStrokeJoin(Paint.Join.MITER);
-		
+        paint.setStrokeWidth(1.0f);
+
 		// adjust for non-(0,0) crop box
 		canvas.translate(-pageSize.getLowerLeftX(), -pageSize.getLowerLeftY());
 		
@@ -455,20 +458,20 @@ public final class PageDrawer extends PDFGraphicsStreamEngine
 //        return getPaint(getGraphicsState().getNonStrokingColor());
 //    }
 
-    // create a new stroke based on the current CTM and the current stroke
-//    private BasicStroke getStroke()
-//    {
-//        PDGraphicsState state = getGraphicsState();
-//
-//        // apply the CTM
-//        float lineWidth = transformWidth(state.getLineWidth());
-//
-//        // minimum line width as used by Adobe Reader
-//        if (lineWidth < 0.25)
-//        {
-//            lineWidth = 0.25f;
-//        }
-//
+    // set stroke based on the current CTM and the current stroke
+    private void setStroke()
+    {
+        PDGraphicsState state = getGraphicsState();
+
+        // apply the CTM
+        float lineWidth = transformWidth(state.getLineWidth());
+
+        // minimum line width as used by Adobe Reader
+        if (lineWidth < 0.25)
+        {
+            lineWidth = 0.25f;
+        }
+
 //        PDLineDashPattern dashPattern = state.getLineDashPattern();
 //        int phaseStart = dashPattern.getPhase();
 //        float[] dashArray = dashPattern.getDashArray();
@@ -488,17 +491,29 @@ public final class PageDrawer extends PDFGraphicsStreamEngine
 //            }
 //        }
 //        return new BasicStroke(lineWidth, state.getLineCap(), state.getLineJoin(),
-//                               state.getMiterLimit(), dashArray, phaseStart);
-//    }
+//                state.getMiterLimit(), dashArray, phaseStart);
+
+        paint.setStrokeWidth(lineWidth);
+        paint.setStrokeCap(state.getLineCap());
+        paint.setStrokeJoin(state.getLineJoin());
+    }
 
     @Override
     public void strokePath() throws IOException
     {
+
 //        graphics.setComposite(getGraphicsState().getStrokingJavaComposite());
 //        graphics.setPaint(getStrokingPaint());
 //        graphics.setStroke(getStroke());
-        setClip();
+//        setClip();
 //        graphics.draw(linePath);
+//        linePath.reset();
+
+        setStroke();
+        setClip();
+        paint.setARGB(255, 0, 0, 0); // TODO set the correct color from graphics state.
+        paint.setStyle(Paint.Style.STROKE);
+        canvas.drawPath(linePath, paint);
         linePath.reset();
     }
 


### PR DESCRIPTION
Added ```Bitmap.Config``` parameter when calling ```renderImage``` in ```PDFRenderer```.

```PageDrawer``` class correctly sets up strokes and draws the strokes to the canvas. 

Using Android's Graphics ```Paint.Cap``` and ```Paint.Join``` enums when passing around line cap style and line join style.