### PR TITLE
Stroking color is applied to the path.

### DIFF
--- a/library/src/main/java/org/apache/pdfbox/contentstream/PDFGraphicsStreamEngine.java
+++ b/library/src/main/java/org/apache/pdfbox/contentstream/PDFGraphicsStreamEngine.java
@@ -1,7 +1,9 @@
 package org.apache.pdfbox.contentstream;
 
-import java.io.IOException;
+import android.graphics.PointF;
 
+import org.apache.pdfbox.contentstream.operator.color.SetStrokingColor;
+import org.apache.pdfbox.contentstream.operator.color.SetStrokingDeviceRGBColor;
 import org.apache.pdfbox.contentstream.operator.graphics.AppendRectangleToPath;
 import org.apache.pdfbox.contentstream.operator.graphics.CloseAndStrokePath;
 import org.apache.pdfbox.contentstream.operator.graphics.CloseFillEvenOddAndStrokePath;
@@ -47,7 +49,7 @@ import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImage;
 
-import android.graphics.PointF;
+import java.io.IOException;
 
 /**
  * PDFStreamEngine subclass for advanced processing of graphics.
@@ -55,16 +57,14 @@ import android.graphics.PointF;
  *
  * @author John Hewson
  */
-public abstract class PDFGraphicsStreamEngine extends PDFStreamEngine
-{
+public abstract class PDFGraphicsStreamEngine extends PDFStreamEngine {
     // may be null, for example if the stream is a tiling pattern
     private final PDPage page;
 
     /**
      * Constructor.
      */
-    protected PDFGraphicsStreamEngine(PDPage page)
-    {
+    protected PDFGraphicsStreamEngine(PDPage page) {
         this.page = page;
 
         addOperator(new CloseFillNonZeroAndStrokePath());
@@ -99,12 +99,12 @@ public abstract class PDFGraphicsStreamEngine extends PDFStreamEngine
         addOperator(new Save());
         addOperator(new Restore());
         addOperator(new AppendRectangleToPath());
-//        addOperator(new SetStrokingDeviceRGBColor());TODO
+        addOperator(new SetStrokingDeviceRGBColor());
 //        addOperator(new SetNonStrokingDeviceRGBColor());TODO
         addOperator(new SetRenderingIntent());
         addOperator(new CloseAndStrokePath());
         addOperator(new StrokePath());
-//        addOperator(new SetStrokingColor());TODO
+        addOperator(new SetStrokingColor());
 //        addOperator(new SetNonStrokingColor());TODO
 //        addOperator(new SetStrokingColorN());TODO
 //        addOperator(new SetNonStrokingColorN());TODO
@@ -134,8 +134,7 @@ public abstract class PDFGraphicsStreamEngine extends PDFStreamEngine
     /**
      * Returns the page.
      */
-    protected final PDPage getPage()
-    {
+    protected final PDPage getPage() {
         return page;
     }
 

--- a/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetColor.java
+++ b/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetColor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pdfbox.contentstream.operator.color;
+
+import org.apache.pdfbox.contentstream.operator.MissingOperandException;
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.contentstream.operator.OperatorProcessor;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColorSpace;
+import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceColorSpace;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * sc,scn,SC,SCN: Sets the color to use for stroking or non-stroking operations.
+ *
+ * @author John Hewson
+ */
+public abstract class SetColor extends OperatorProcessor {
+    @Override
+    public void process(Operator operator, List<COSBase> arguments) throws IOException {
+        PDColorSpace colorSpace = getColorSpace();
+        if (colorSpace instanceof PDDeviceColorSpace &&
+                arguments.size() < colorSpace.getNumberOfComponents()) {
+            throw new MissingOperandException(operator, arguments);
+        }
+        COSArray array = new COSArray();
+        array.addAll(arguments);
+        setColor(new PDColor(array, colorSpace));
+    }
+
+    /**
+     * Returns either the stroking or non-stroking color value.
+     *
+     * @return The stroking or non-stroking color value.
+     */
+    protected abstract PDColor getColor();
+
+    /**
+     * Sets either the stroking or non-stroking color value.
+     *
+     * @param color The stroking or non-stroking color value.
+     */
+    protected abstract void setColor(PDColor color);
+
+    /**
+     * Returns either the stroking or non-stroking color space.
+     *
+     * @return The stroking or non-stroking color space.
+     */
+    protected abstract PDColorSpace getColorSpace();
+}

--- a/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetStrokingColor.java
+++ b/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetStrokingColor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pdfbox.contentstream.operator.color;
+
+import org.apache.pdfbox.pdmodel.graphics.color.PDColor;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColorSpace;
+
+/**
+ * SC: Sets the colour to use for stroking stroking operations.
+ *
+ * @author John Hewson
+ */
+public class SetStrokingColor extends SetColor {
+    /**
+     * Returns the stroking color.
+     *
+     * @return The stroking color.
+     */
+    @Override
+    protected PDColor getColor() {
+        return context.getGraphicsState().getStrokingColor();
+    }
+
+    /**
+     * Sets the stroking color.
+     *
+     * @param color The new stroking color.
+     */
+    @Override
+    protected void setColor(PDColor color) {
+        context.getGraphicsState().setStrokingColor(color);
+    }
+
+    /**
+     * Returns the stroking color space.
+     *
+     * @return The stroking color space.
+     */
+    @Override
+    protected PDColorSpace getColorSpace() {
+        return context.getGraphicsState().getStrokingColorSpace();
+    }
+
+    @Override
+    public String getName() {
+        return "SC";
+    }
+}

--- a/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetStrokingDeviceRGBColor.java
+++ b/library/src/main/java/org/apache/pdfbox/contentstream/operator/color/SetStrokingDeviceRGBColor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pdfbox.contentstream.operator.color;
+
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.graphics.color.PDColorSpace;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * RG: Set the stroking colour space to DeviceRGB and set the colour to use for stroking operations.
+ *
+ * @author John Hewson
+ */
+public class SetStrokingDeviceRGBColor extends SetStrokingColor {
+    /**
+     * RG Set the stroking colour space to DeviceRGB and set the colour to
+     * use for stroking operations.
+     *
+     * @param operator  The operator that is being executed.
+     * @param arguments List
+     * @throws IOException If the color space cannot be read.
+     */
+    public void process(Operator operator, List<COSBase> arguments) throws IOException {
+        PDColorSpace cs = context.getResources().getColorSpace(COSName.DEVICERGB);
+        context.getGraphicsState().setStrokingColorSpace(cs);
+        super.process(operator, arguments);
+    }
+
+    @Override
+    public String getName() {
+        return "RG";
+    }
+}

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
@@ -79,19 +79,19 @@ public final class PDResources implements COSObjectable
 	/**
 	 * Returns the color space resource with the given name, or null if none exists.
 	 */
-//	public PDColorSpace getColorSpace(COSName name) throws IOException
-//	{
-//		// get the instance
-//		COSBase object = get(COSName.COLORSPACE, name);
-//		if (object != null)
-//		{
-//			return PDColorSpace.create(object, this);
-//		}
-//		else
-//		{
-//			return PDColorSpace.create(name, this);
-//		}
-//	} TODO
+	public PDColorSpace getColorSpace(COSName name) throws IOException
+	{
+		// get the instance
+		COSBase object = get(COSName.COLORSPACE, name);
+		if (object != null)
+		{
+			return PDColorSpace.create(object, this);
+		}
+		else
+		{
+			return PDColorSpace.create(name, this);
+		}
+	}
 
 	/**
 	 * Returns true if the given color space name exists in these resources.

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDColorSpace.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDColorSpace.java
@@ -1,11 +1,14 @@
 package org.apache.pdfbox.pdmodel.graphics.color;
 
-import java.io.IOException;
-
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.pdmodel.MissingResourceException;
+import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.COSObjectable;
+
+import java.io.IOException;
 
 /**
  * A color space specifies how the colours of graphics objects will be painted on the page.
@@ -13,193 +16,151 @@ import org.apache.pdfbox.pdmodel.common.COSObjectable;
  * @author John Hewson
  * @author Ben Litchfield
  */
-public abstract class PDColorSpace implements COSObjectable
-{
+public abstract class PDColorSpace implements COSObjectable {
     /**
      * Creates a color space space given a name or array.
+     *
      * @param colorSpace the color space COS object
      * @return a new color space
      * @throws IOException if the color space is unknown or cannot be created
      */
-//    public static PDColorSpace create(COSBase colorSpace) throws IOException
-//    {
-//        return create(colorSpace, null);
-//    } TODO
+    public static PDColorSpace create(COSBase colorSpace) throws IOException {
+        return create(colorSpace, null);
+    }
 
     /**
      * Creates a color space given a name or array.
+     *
      * @param colorSpace the color space COS object
-     * @param resources the current resources.
+     * @param resources  the current resources.
      * @return a new color space
      * @throws MissingResourceException if the color space is missing in the resources dictionary
-     * @throws IOException if the color space is unknown or cannot be created
+     * @throws IOException              if the color space is unknown or cannot be created
      */
-//    public static PDColorSpace create(COSBase colorSpace,
-//                                      PDResources resources)
-//                                      throws IOException
-//    {
-//        if (colorSpace instanceof COSObject)
-//        {
-//            return create(((COSObject) colorSpace).getObject(), resources);
-//        }
-//        else if (colorSpace instanceof COSName)
-//        {
-//            COSName name = (COSName)colorSpace;
-//
-//            // default color spaces
-//            if (resources != null)
-//            {
-//                COSName defaultName = null;
-//                if (name.equals(COSName.DEVICECMYK) &&
-//                    resources.hasColorSpace(COSName.DEFAULT_CMYK))
-//                {
-//                    defaultName = COSName.DEFAULT_CMYK;
-//                }
-//                else if (name.equals(COSName.DEVICERGB) &&
-//                         resources.hasColorSpace(COSName.DEFAULT_RGB))
-//                {
-//                    defaultName = COSName.DEFAULT_RGB;
-//                }
-//                else if (name.equals(COSName.DEVICEGRAY) &&
-//                         resources.hasColorSpace(COSName.DEFAULT_GRAY))
-//                {
-//                    defaultName = COSName.DEFAULT_GRAY;
-//                }
-//
-//                if (resources.hasColorSpace(defaultName))
-//                {
-//                    return resources.getColorSpace(defaultName);
-//                }
-//            }
-//
-//            // built-in color spaces
-//            if (name == COSName.DEVICECMYK || name == COSName.CMYK)
-//            {
-//                return PDDeviceCMYK.INSTANCE;
-//            }
-//            else if (name == COSName.DEVICERGB || name == COSName.RGB)
-//            {
-//                return PDDeviceRGB.INSTANCE;
-//            }
-//            else if (name == COSName.DEVICEGRAY || name == COSName.G)
-//            {
-//                return PDDeviceGray.INSTANCE;
-//            }
-//            else if (name == COSName.PATTERN)
-//            {
-//                return new PDPattern(resources);
-//            }
-//            else if (resources != null)
-//            {
-//                if (!resources.hasColorSpace(name))
-//                {
-//                    throw new MissingResourceException("Missing color space: " + name.getName());
-//                }
-//                return resources.getColorSpace(name);
-//            }
-//            else
-//            {
-//                throw new MissingResourceException("Unknown color space: " + name.getName());
-//            }
-//        }
-//        else if (colorSpace instanceof COSArray)
-//        {
-//            COSArray array = (COSArray)colorSpace;
-//            COSName name = (COSName)array.get(0);
+    public static PDColorSpace create(COSBase colorSpace,
+                                      PDResources resources)
+            throws IOException {
+        if (colorSpace instanceof COSObject) {
+            return create(((COSObject) colorSpace).getObject(), resources);
+        } else if (colorSpace instanceof COSName) {
+            COSName name = (COSName) colorSpace;
+
+            // default color spaces
+            if (resources != null) {
+                COSName defaultName = null;
+                if (name.equals(COSName.DEVICECMYK) &&
+                        resources.hasColorSpace(COSName.DEFAULT_CMYK)) {
+                    defaultName = COSName.DEFAULT_CMYK;
+                } else if (name.equals(COSName.DEVICERGB) &&
+                        resources.hasColorSpace(COSName.DEFAULT_RGB)) {
+                    defaultName = COSName.DEFAULT_RGB;
+                } else if (name.equals(COSName.DEVICEGRAY) &&
+                        resources.hasColorSpace(COSName.DEFAULT_GRAY)) {
+                    defaultName = COSName.DEFAULT_GRAY;
+                }
+
+                if (resources.hasColorSpace(defaultName)) {
+                    return resources.getColorSpace(defaultName);
+                }
+            }
+
+            // built-in color spaces
+            /*if (name == COSName.DEVICECMYK || name == COSName.CMYK) {
+                return PDDeviceCMYK.INSTANCE;
+            } else*/ if (name == COSName.DEVICERGB || name == COSName.RGB) {
+                return PDDeviceRGB.INSTANCE;
+            } else if (name == COSName.DEVICEGRAY || name == COSName.G) {
+                return PDDeviceGray.INSTANCE;
+            } /*else if (name == COSName.PATTERN) {
+                return new PDPattern(resources);
+            } */else if (resources != null) {
+                if (!resources.hasColorSpace(name)) {
+                    throw new MissingResourceException("Missing color space: " + name.getName());
+                }
+                return resources.getColorSpace(name);
+            } else {
+                throw new MissingResourceException("Unknown color space: " + name.getName());
+            }
+        } else if (colorSpace instanceof COSArray) {
+            COSArray array = (COSArray) colorSpace;
+            COSName name = (COSName) array.get(0);
 //
 //            // TODO cache these returned color spaces?
 //
-//            if (name == COSName.CALGRAY)
-//            {
+//            if (name == COSName.CALGRAY) {
 //                return new PDCalGray(array);
-//            }
-//            else if (name == COSName.CALRGB)
-//            {
+//            } else if (name == COSName.CALRGB) {
 //                return new PDCalRGB(array);
-//            }
-//            else if (name == COSName.DEVICEN)
-//            {
+//            } else if (name == COSName.DEVICEN) {
 //                return new PDDeviceN(array);
-//            }
-//            else if (name == COSName.INDEXED || name == COSName.I)
-//            {
+//            } else if (name == COSName.INDEXED || name == COSName.I) {
 //                return new PDIndexed(array);
-//            }
-//            else if (name == COSName.SEPARATION)
-//            {
+//            } else if (name == COSName.SEPARATION) {
 //                return new PDSeparation(array);
-//            }
-//            else if (name == COSName.ICCBASED)
-//            {
+//            } else if (name == COSName.ICCBASED) {
 //                return new PDICCBased(array);
-//            }
-//            else if (name == COSName.LAB)
-//            {
+//            } else if (name == COSName.LAB) {
 //                return new PDLab(array);
-//            }
-//            else if (name == COSName.PATTERN)
-//            {
-//                if (array.size() == 1)
-//                {
+//            } else if (name == COSName.PATTERN) {
+//                if (array.size() == 1) {
 //                    return new PDPattern(resources);
-//                }
-//                else
-//                {
+//                } else {
 //                    return new PDPattern(resources, PDColorSpace.create(array.get(1)));
 //                }
-//            }
-//            else if (name == COSName.DEVICECMYK || name == COSName.CMYK ||
-//                     name == COSName.DEVICERGB  || name == COSName.RGB ||
-//                     name == COSName.DEVICEGRAY || name == COSName.PATTERN)
-//            {
+//            } else if (name == COSName.DEVICECMYK || name == COSName.CMYK ||
+//                    name == COSName.DEVICERGB || name == COSName.RGB ||
+//                    name == COSName.DEVICEGRAY || name == COSName.PATTERN) {
 //                // not allowed in an array, but we sometimes encounter these regardless
 //                return create(name, resources);
-//            }
-//            else
-//            {
+//            } else {
 //                throw new IOException("Invalid color space kind: " + name);
 //            }
-//        }
-//        else
-//        {
-//            throw new IOException("Expected a name or array but got: " + colorSpace);
-//        }
-//    } TODO
+
+            throw new IOException("Invalid color space kind: " + name);
+        } else {
+            throw new IOException("Expected a name or array but got: " + colorSpace);
+        }
+    }
 
     // array for the given parameters
     protected COSArray array;
 
     /**
      * Returns the name of the color space.
+     *
      * @return the name of the color space
      */
     public abstract String getName();
 
     /**
      * Returns the number of components in this color space
+     *
      * @return the number of components in this color space
      */
     public abstract int getNumberOfComponents();
 
     /**
      * Returns the default decode array for this color space.
+     *
      * @return the default decode array
      */
     public abstract float[] getDefaultDecode(int bitsPerComponent);
 
     /**
      * Returns the initial color value for this color space.
+     *
      * @return the initial color value for this color space
      */
     public abstract PDColor getInitialColor();
 
     /**
      * Returns the RGB equivalent of the given color value.
+     *
      * @param value a color value with component values between 0 and 1
      * @return an array of R,G,B value between 0 and 255
      * @throws IOException if the color conversion fails
      */
-//    public abstract float[] toRGB(float[] value) throws IOException; TODO
+    public abstract float[] toRGB(float[] value) throws IOException;
 
     /**
      * Returns the (A)RGB equivalent of the given raster.
@@ -212,7 +173,8 @@ public abstract class PDColorSpace implements COSObjectable
     /**
      * Returns the (A)RGB equivalent of the given raster, using the given AWT color space
      * to perform the conversion.
-     * @param raster the source raster
+     *
+     * @param raster     the source raster
      * @param colorSpace the AWT
      * @return an (A)RGB buffered image
      */
@@ -233,10 +195,8 @@ public abstract class PDColorSpace implements COSObjectable
 //        op.filter(src, dest);
 //        return dest;
 //    } TODO
-
     @Override
-    public COSBase getCOSObject()
-    {
+    public COSBase getCOSObject() {
         return array;
     }
 }

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceRGB.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/color/PDDeviceRGB.java
@@ -9,16 +9,16 @@ import org.apache.pdfbox.cos.COSName;
  * @author Ben Litchfield
  * @author John Hewson
  */
-public final class PDDeviceRGB extends PDDeviceColorSpace
-{
-    /**  This is the single instance of this class. */
+public final class PDDeviceRGB extends PDDeviceColorSpace {
+    /**
+     * This is the single instance of this class.
+     */
     public static final PDDeviceRGB INSTANCE = new PDDeviceRGB();
 
-//    private final ColorSpace colorSpaceRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB); TODO
-    private final PDColor initialColor = new PDColor(new float[] { 0, 0, 0 }, this);
+    //    private final ColorSpace colorSpaceRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB)
+    private final PDColor initialColor = new PDColor(new float[]{0, 0, 0}, this);
 
-    private PDDeviceRGB()
-    {
+    private PDDeviceRGB() {
         // there is a JVM bug which results in a CMMException which appears to be a race
         // condition caused by lazy initialization of the color transform, so we perform
         // an initial color conversion while we're still in a static context, see PDFBOX-2184
@@ -26,36 +26,36 @@ public final class PDDeviceRGB extends PDDeviceColorSpace
     }
 
     @Override
-    public String getName()
-    {
+    public String getName() {
         return COSName.DEVICERGB.getName();
     }
 
     /**
      * @inheritDoc
      */
-    public int getNumberOfComponents()
-    {
+    public int getNumberOfComponents() {
         return 3;
     }
 
     @Override
-    public float[] getDefaultDecode(int bitsPerComponent)
-    {
-        return new float[] { 0, 1, 0, 1, 0, 1 };
+    public float[] getDefaultDecode(int bitsPerComponent) {
+        return new float[]{0, 1, 0, 1, 0, 1};
     }
 
     @Override
-    public PDColor getInitialColor()
-    {
+    public PDColor getInitialColor() {
         return initialColor;
     }
 
-//    @Override
-//    public float[] toRGB(float[] value)
-//    {
-//        return colorSpaceRGB.toRGB(value);
-//    } TODO
+    @Override
+    public float[] toRGB(float[] value) {
+        // This is just assuming that the values being sent to it are already in RGB color space.
+        if (value.length == 3) {
+            return value;
+        } else {
+            return initialColor.getComponents();
+        }
+    }
 
 //    @Override
 //    public BufferedImage toRGBImage(WritableRaster raster) throws IOException


### PR DESCRIPTION
When drawing paths the stroking color is now applied when the PageDrawer class draws to graphics. 

This pull request only applies to the DeviceRGB color space and is not likely to work for any other color spaces or even break. This is due to our limitation of Android not having a replacement for the ColorSpace library that Java has with AWT.