### PR TITLE
Visual digital signature

### DIFF
--- a/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
@@ -1,6 +1,7 @@
 package org.apache.pdfbox.pdmodel.graphics.image;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -105,11 +106,11 @@ public final class JPEGFactory extends ImageFactory
 	 * @return a new Image XObject
 	 * @throws IOException if the JPEG data cannot be written
 	 */
-	//    public static PDImageXObject createFromImage(PDDocument document, BufferedImage image)
-	//        throws IOException
-	//    {
-	//        return createFromImage(document, image, 0.75f);
-	//    }TODO
+    public static PDImageXObject createFromImage(PDDocument document, Bitmap image)
+        throws IOException
+    {
+        return createFromImage(document, image, 0.75f);
+    }
 
 	/**
 	 * Creates a new JPEG Image XObject from a Buffered Image and a given quality.
@@ -120,11 +121,11 @@ public final class JPEGFactory extends ImageFactory
 	 * @return a new Image XObject
 	 * @throws IOException if the JPEG data cannot be written
 	 */
-	//    public static PDImageXObject createFromImage(PDDocument document, BufferedImage image,
-	//                                                 float quality) throws IOException
-	//    {
-	//        return createFromImage(document, image, quality, 72);
-	//    }TODO
+    public static PDImageXObject createFromImage(PDDocument document, Bitmap image,
+            float quality) throws IOException
+    {
+        return createFromImage(document, image, quality, 72);
+    }
 
 	/**
 	 * Creates a new JPEG Image XObject from a Buffered Image, a given quality and DPI.
@@ -135,11 +136,11 @@ public final class JPEGFactory extends ImageFactory
 	 * @return a new Image XObject
 	 * @throws IOException if the JPEG data cannot be written
 	 */
-	//    public static PDImageXObject createFromImage(PDDocument document, BufferedImage image,
-	//                                                 float quality, int dpi) throws IOException
-	//    {
-	//        return createJPEG(document, image, quality, dpi);
-	//    }TODO
+    public static PDImageXObject createFromImage(PDDocument document, Bitmap image,
+                                                 float quality, int dpi) throws IOException
+    {
+        return createJPEG(document, image, quality, dpi);
+    }
 
 	// returns the alpha channel of an image
 	//    private static BufferedImage getAlphaImage(BufferedImage image) throws IOException
@@ -166,9 +167,20 @@ public final class JPEGFactory extends ImageFactory
 	//    }TODO
 
 	// Creates an Image XObject from a Buffered Image using JAI Image I/O
-	//    private static PDImageXObject createJPEG(PDDocument document, BufferedImage image,
-	//                                             float quality, int dpi) throws IOException
-	//    {
+    private static PDImageXObject createJPEG(PDDocument document, Bitmap image,
+            float quality, int dpi) throws IOException
+    {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(); 
+        image.compress(Bitmap.CompressFormat.JPEG, (int)(quality * 100), bos); 
+        byte[] bitmapData = bos.toByteArray();
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(bitmapData);
+
+        PDImageXObject pdImage = new PDImageXObject(document, byteStream, 
+                COSName.DCT_DECODE, image.getWidth(), image.getHeight(), 
+                8, //awtImage.getColorModel().getComponentSize(0),
+                PDDeviceRGB.INSTANCE //getColorSpaceFromAWT(awtImage));
+        );
+
 	//        // extract alpha channel (if any)
 	//        BufferedImage awtColorImage = getColorImage(image);
 	//        BufferedImage awtAlphaImage = getAlphaImage(image);
@@ -191,8 +203,8 @@ public final class JPEGFactory extends ImageFactory
 	//            pdImage.getCOSStream().setItem(COSName.SMASK, xAlpha);
 	//        }
 	//
-	//        return pdImage;
-	//    }TODO
+	        return pdImage;
+	}
 
 //	private static void encodeImageToJPEGStream(BufferedImage image, float quality, int dpi,
 //			OutputStream out) throws IOException

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/graphics/image/JPEGFactory.java
@@ -2,6 +2,7 @@ package org.apache.pdfbox.pdmodel.graphics.image;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -9,9 +10,15 @@ import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB;
+import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceGray;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Paint;
 
 /**
  * Factory for creating a PDImageXObject containing a JPEG compressed image.
@@ -143,67 +150,58 @@ public final class JPEGFactory extends ImageFactory
     }
 
 	// returns the alpha channel of an image
-	//    private static BufferedImage getAlphaImage(BufferedImage image) throws IOException
-	//    {
-	//        if (!image.getColorModel().hasAlpha())
-	//        {
-	//            return null;
-	//        }
-	//        if (image.getTransparency() == Transparency.BITMASK)
-	//        {
-	//            throw new UnsupportedOperationException("BITMASK Transparency JPEG compression is not" +
-	//" useful, use LosslessImageFactory instead");
-	//        }
-	//        WritableRaster alphaRaster = image.getAlphaRaster();
-	//        if (alphaRaster == null)
-	//        {
-	//	// happens sometimes (PDFBOX-2654) despite colormodel claiming to have alpha
-	//            return null;
-	//        }
-	//        BufferedImage alphaImage = new BufferedImage(image.getWidth(), image.getHeight(),
-	//    BufferedImage.TYPE_BYTE_GRAY);
-	//        alphaImage.setData(alphaRaster);
-	//        return alphaImage;
-	//    }TODO
+    private static Bitmap getAlphaImage(Bitmap image) throws IOException
+    {
+        if (!image.hasAlpha())
+        {
+            return null;
+        }
+        return image.extractAlpha(); 
+    }
 
 	// Creates an Image XObject from a Buffered Image using JAI Image I/O
     private static PDImageXObject createJPEG(PDDocument document, Bitmap image,
             float quality, int dpi) throws IOException
     {
+        Bitmap whiteImage = Bitmap.createBitmap(image.getWidth(), image.getHeight(),image.getConfig()); 
+        Bitmap alphaImage = getAlphaImage(image);
+
+        whiteImage.eraseColor(Color.WHITE);
+        Canvas canvas = new Canvas(whiteImage);
+        canvas.drawBitmap(image, 0f, 0f, null);
+        image.recycle();
+
         ByteArrayOutputStream bos = new ByteArrayOutputStream(); 
-        image.compress(Bitmap.CompressFormat.JPEG, (int)(quality * 100), bos); 
+        whiteImage.compress(Bitmap.CompressFormat.JPEG, (int)(quality * 100), bos); 
         byte[] bitmapData = bos.toByteArray();
         ByteArrayInputStream byteStream = new ByteArrayInputStream(bitmapData);
 
         PDImageXObject pdImage = new PDImageXObject(document, byteStream, 
-                COSName.DCT_DECODE, image.getWidth(), image.getHeight(), 
-                8, //awtImage.getColorModel().getComponentSize(0),
-                PDDeviceRGB.INSTANCE //getColorSpaceFromAWT(awtImage));
+                COSName.DCT_DECODE, whiteImage.getWidth(), whiteImage.getHeight(), 
+                8, 
+                PDDeviceRGB.INSTANCE 
         );
 
-	//        // extract alpha channel (if any)
-	//        BufferedImage awtColorImage = getColorImage(image);
-	//        BufferedImage awtAlphaImage = getAlphaImage(image);
-	//
-	//        // create XObject
-	//        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-	//        encodeImageToJPEGStream(awtColorImage, quality, dpi, baos);
-	//        ByteArrayInputStream byteStream = new ByteArrayInputStream(baos.toByteArray());
-	//        
-	//        
-	//        PDImageXObject pdImage = new PDImageXObject(document, byteStream, 
-	//                COSName.DCT_DECODE, awtColorImage.getWidth(), awtColorImage.getHeight(), 
-	//                awtColorImage.getColorModel().getComponentSize(0),
-	//                getColorSpaceFromAWT(awtColorImage));
-	//
-	//        // alpha -> soft mask
-	//        if (awtAlphaImage != null)
-	//        {
-	//            PDImage xAlpha = JPEGFactory.createFromImage(document, awtAlphaImage, quality);
-	//            pdImage.getCOSStream().setItem(COSName.SMASK, xAlpha);
-	//        }
-	//
-	        return pdImage;
+        // alpha -> soft mask
+        if (alphaImage != null)
+        {
+            ByteArrayOutputStream aBos = new ByteArrayOutputStream(); 
+            // This is problematic at the moment as
+            // compress does not seem to support ALPHA_8 as returned by getAlphaImage()
+            boolean ok = alphaImage.compress(Bitmap.CompressFormat.JPEG, (int)(quality * 100), aBos); 
+            System.err.println("Compressing alpha image: " + String.valueOf(ok) + " " + alphaImage.getConfig().toString());
+            byte[] aBitmapData = aBos.toByteArray();
+            ByteArrayInputStream aByteStream = new ByteArrayInputStream(aBitmapData);
+
+            PDImageXObject xAlpha = new PDImageXObject(document, aByteStream, 
+                    COSName.DCT_DECODE, alphaImage.getWidth(), alphaImage.getHeight(), 
+                    8, 
+                    PDDeviceGray.INSTANCE 
+            );
+
+            pdImage.getCOSStream().setItem(COSName.SMASK, xAlpha);
+        }
+	    return pdImage;
 	}
 
 //	private static void encodeImageToJPEGStream(BufferedImage image, float quality, int dpi,

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDFTemplateBuilder.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDFTemplateBuilder.java
@@ -15,6 +15,8 @@ import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.apache.pdfbox.util.awt.AffineTransform;
 
+import android.graphics.Bitmap;
+
 /**
  * That class builds visible signature template which will be added in our PDF document.
  * @author Vakhtang Koroghlishvili
@@ -92,7 +94,7 @@ public interface PDFTemplateBuilder
      * @param image
      * @throws IOException
      */
-//	void createSignatureImage(PDDocument template, BufferedImage image) throws IOException;TODO
+	void createSignatureImage(PDDocument template, Bitmap image) throws IOException;
 	
 	/**
 	 * 

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDFTemplateCreator.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDFTemplateCreator.java
@@ -1,5 +1,19 @@
 package org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.common.PDStream;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+import org.apache.pdfbox.util.awt.AffineTransform;
+import android.util.Log;
 /**
  * Using that class, we build pdf template.
  * @author Vakhtang Koroghlishvili
@@ -23,10 +37,10 @@ public class PDFTemplateCreator
      * 
      * @return PDFStructure
      */
-//    public PDFTemplateStructure getPdfStructure()
-//    {
-//        return pdfBuilder.getStructure();
-//    }TODO
+    public PDFTemplateStructure getPdfStructure()
+    {
+        return pdfBuilder.getStructure();
+    }
 
     /**
      * this method builds pdf  step by step, and finally it returns stream of visible signature
@@ -34,95 +48,95 @@ public class PDFTemplateCreator
      * @return InputStream
      * @throws IOException
      */
-//    public InputStream buildPDF(PDVisibleSignDesigner properties) throws IOException
-//    {
-//        logger.info("pdf building has been started");
-//        PDFTemplateStructure pdfStructure = pdfBuilder.getStructure();
-//
-//        // we create array of [Text, ImageB, ImageC, ImageI]
-//        pdfBuilder.createProcSetArray();
-//        
-//        //create page
-//        pdfBuilder.createPage(properties);
-//        PDPage page = pdfStructure.getPage();
-//
-//        //create template
-//        pdfBuilder.createTemplate(page);
-//        PDDocument template = pdfStructure.getTemplate();
-//        
-//        //create /AcroForm
-//        pdfBuilder.createAcroForm(template);
-//        PDAcroForm acroForm = pdfStructure.getAcroForm();
-//
-//        // AcroForm contains singature fields
-//        pdfBuilder.createSignatureField(acroForm);
-//        PDSignatureField pdSignatureField = pdfStructure.getSignatureField();
-//        
-//        // create signature
-//        pdfBuilder.createSignature(pdSignatureField, page, properties.getSignatureFieldName());
-//       
-//        // that is /AcroForm/DR entry
-//        pdfBuilder.createAcroFormDictionary(acroForm, pdSignatureField);
-//        
-//        // create AffineTransform
-//        pdfBuilder.createAffineTransform(properties.getAffineTransformParams());
-//        AffineTransform transform = pdfStructure.getAffineTransform();
-//       
-//        // rectangle, formatter, image. /AcroForm/DR/XObject contains that form
-//        pdfBuilder.createSignatureRectangle(pdSignatureField, properties);
-//        pdfBuilder.createFormaterRectangle(properties.getFormaterRectangleParams());
-//        PDRectangle formater = pdfStructure.getFormaterRectangle();
-//        pdfBuilder.createSignatureImage(template, properties.getImage());
-//
-//        // create form stream, form and  resource. 
-//        pdfBuilder.createHolderFormStream(template);
-//        PDStream holderFormStream = pdfStructure.getHolderFormStream();
-//        pdfBuilder.createHolderFormResources();
-//        PDResources holderFormResources = pdfStructure.getHolderFormResources();
-//        pdfBuilder.createHolderForm(holderFormResources, holderFormStream, formater);
-//        
-//        // that is /AP entry the appearance dictionary.
-//        pdfBuilder.createAppearanceDictionary(pdfStructure.getHolderForm(), pdSignatureField);
-//        
-//        // inner form stream, form and resource (hlder form containts inner form)
-//        pdfBuilder.createInnerFormStream(template);
-//        pdfBuilder.createInnerFormResource();
-//        PDResources innerFormResource = pdfStructure.getInnerFormResources();
-//        pdfBuilder.createInnerForm(innerFormResource, pdfStructure.getInnterFormStream(), formater);
-//        PDFormXObject innerForm = pdfStructure.getInnerForm();
-//       
-//        // inner form must be in the holder form as we wrote
-//        pdfBuilder.insertInnerFormToHolerResources(innerForm, holderFormResources);
-//        
-//        //  Image form is in this structure: /AcroForm/DR/FRM0/Resources/XObject/n0
-//        pdfBuilder.createImageFormStream(template);
-//        PDStream imageFormStream = pdfStructure.getImageFormStream();
-//        pdfBuilder.createImageFormResources();
-//        PDResources imageFormResources = pdfStructure.getImageFormResources();
-//        pdfBuilder.createImageForm(imageFormResources, innerFormResource, imageFormStream, formater,
-//                transform, pdfStructure.getImage());
-//       
-//        // now inject procSetArray
-//        pdfBuilder.injectProcSetArray(innerForm, page, innerFormResource, imageFormResources,
-//                holderFormResources, pdfStructure.getProcSet());
-//
-//        COSName imgFormName = pdfStructure.getImageFormName();
-//        COSName imgName = pdfStructure.getImageName();
-//        COSName innerFormName = pdfStructure.getInnerFormName();
-//
-//        // now create Streams of AP
-//        pdfBuilder.injectAppearanceStreams(holderFormStream, imageFormStream, imageFormStream,
-//                imgFormName, imgName, innerFormName, properties);
-//        pdfBuilder.createVisualSignature(template);
-//        pdfBuilder.createWidgetDictionary(pdSignatureField, holderFormResources);
-//        
-//        ByteArrayInputStream in = pdfStructure.getTemplateAppearanceStream();
-//        logger.info("stream returning started, size= " + in.available());
-//        
-//        // we must close the document
-//        template.close();
-//        
-//        // return result of the stream 
-//        return in;
-//    }TODO
+    public InputStream buildPDF(PDVisibleSignDesigner properties) throws IOException
+    {
+        Log.i("PdfBoxAndroid", "pdf building has been started");
+        PDFTemplateStructure pdfStructure = pdfBuilder.getStructure();
+
+        // we create array of [Text, ImageB, ImageC, ImageI]
+        pdfBuilder.createProcSetArray();
+        
+        //create page
+        pdfBuilder.createPage(properties);
+        PDPage page = pdfStructure.getPage();
+
+        //create template
+        pdfBuilder.createTemplate(page);
+        PDDocument template = pdfStructure.getTemplate();
+        
+        //create /AcroForm
+        pdfBuilder.createAcroForm(template);
+        PDAcroForm acroForm = pdfStructure.getAcroForm();
+
+        // AcroForm contains singature fields
+        pdfBuilder.createSignatureField(acroForm);
+        PDSignatureField pdSignatureField = pdfStructure.getSignatureField();
+        
+        // create signature
+        pdfBuilder.createSignature(pdSignatureField, page, properties.getSignatureFieldName());
+       
+        // that is /AcroForm/DR entry
+        pdfBuilder.createAcroFormDictionary(acroForm, pdSignatureField);
+        
+        // create AffineTransform
+        pdfBuilder.createAffineTransform(properties.getAffineTransformParams());
+        AffineTransform transform = pdfStructure.getAffineTransform();
+       
+        // rectangle, formatter, image. /AcroForm/DR/XObject contains that form
+        pdfBuilder.createSignatureRectangle(pdSignatureField, properties);
+        pdfBuilder.createFormaterRectangle(properties.getFormaterRectangleParams());
+        PDRectangle formater = pdfStructure.getFormaterRectangle();
+        pdfBuilder.createSignatureImage(template, properties.getImage());
+
+        // create form stream, form and  resource. 
+        pdfBuilder.createHolderFormStream(template);
+        PDStream holderFormStream = pdfStructure.getHolderFormStream();
+        pdfBuilder.createHolderFormResources();
+        PDResources holderFormResources = pdfStructure.getHolderFormResources();
+        pdfBuilder.createHolderForm(holderFormResources, holderFormStream, formater);
+       
+        // that is /AP entry the appearance dictionary.
+        pdfBuilder.createAppearanceDictionary(pdfStructure.getHolderForm(), pdSignatureField);
+        
+        // inner form stream, form and resource (hlder form containts inner form)
+        pdfBuilder.createInnerFormStream(template);
+        pdfBuilder.createInnerFormResource();
+        PDResources innerFormResource = pdfStructure.getInnerFormResources();
+        pdfBuilder.createInnerForm(innerFormResource, pdfStructure.getInnterFormStream(), formater);
+       PDFormXObject innerForm = pdfStructure.getInnerForm();
+       
+        // inner form must be in the holder form as we wrote
+        pdfBuilder.insertInnerFormToHolerResources(innerForm, holderFormResources);
+        
+        //  Image form is in this structure: /AcroForm/DR/FRM0/Resources/XObject/n0
+        pdfBuilder.createImageFormStream(template);
+        PDStream imageFormStream = pdfStructure.getImageFormStream();
+        pdfBuilder.createImageFormResources();
+        PDResources imageFormResources = pdfStructure.getImageFormResources();
+        pdfBuilder.createImageForm(imageFormResources, innerFormResource, imageFormStream, formater,
+                transform, pdfStructure.getImage());
+       
+        // now inject procSetArray
+        pdfBuilder.injectProcSetArray(innerForm, page, innerFormResource, imageFormResources,
+                holderFormResources, pdfStructure.getProcSet());
+
+        COSName imgFormName = pdfStructure.getImageFormName();
+        COSName imgName = pdfStructure.getImageName();
+        COSName innerFormName = pdfStructure.getInnerFormName();
+
+       // now create Streams of AP
+        pdfBuilder.injectAppearanceStreams(holderFormStream, imageFormStream, imageFormStream,
+                imgFormName, imgName, innerFormName, properties);
+        pdfBuilder.createVisualSignature(template);
+        pdfBuilder.createWidgetDictionary(pdSignatureField, holderFormResources);
+        
+        ByteArrayInputStream in = pdfStructure.getTemplateAppearanceStream();
+        Log.i("PdfBoxAndroid", "stream returning started, size= " + in.available());
+        
+        // we must close the document
+        template.close();
+        
+        // return result of the stream 
+        return in;
+    }
 }

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSigBuilder.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSigBuilder.java
@@ -14,6 +14,7 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.common.PDStream;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
@@ -23,6 +24,7 @@ import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.apache.pdfbox.util.awt.AffineTransform;
 
 import android.util.Log;
+import android.graphics.Bitmap;
 
 /**
  * Implementation of PDFTemplateBuilder.
@@ -147,12 +149,12 @@ public class PDVisibleSigBuilder implements PDFTemplateBuilder
         Log.i("PdfBoxAndroid", "ProcSet array has been created");
     }
 
-//    @Override
-//    public void createSignatureImage(PDDocument template, BufferedImage image) throws IOException
-//    {
-//        pdfStructure.setImage(JPEGFactory.createFromImage(template, image));
-//        Log.i("PdfBoxAndroid", "Visible Signature Image has been created");
-//    }TODO
+    @Override
+    public void createSignatureImage(PDDocument template, Bitmap image) throws IOException
+    {
+        pdfStructure.setImage(JPEGFactory.createFromImage(template, image));
+        Log.i("PdfBoxAndroid", "Visible Signature Image has been created");
+    }
 
     @Override
     public void createFormaterRectangle(byte[] params)

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSigProperties.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSigProperties.java
@@ -29,7 +29,7 @@ public class PDVisibleSigProperties
     {
         PDFTemplateBuilder builder = new PDVisibleSigBuilder();
         PDFTemplateCreator creator = new PDFTemplateCreator(builder);
-//        setVisibleSignature(creator.buildPDF(getPdVisibleSignature()));TODO
+        setVisibleSignature(creator.buildPDF(getPdVisibleSignature()));
     }
 
     /**

--- a/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSignDesigner.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/interactive/digitalsignature/visible/PDVisibleSignDesigner.java
@@ -1,8 +1,13 @@
 package org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible;
 
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 
 /**
  * Builder for visible signature design.
@@ -18,7 +23,7 @@ public class PDVisibleSignDesigner
     private float yAxis;
     private float pageHeight;
     private float pageWidth;
-//    private BufferedImage image;TODO
+    private Bitmap image;
     private String signatureFieldName = "sig"; // default
     private byte[] formaterRectangleParams = { 0, 0, 100, 50 }; // default
     private byte[] AffineTransformParams =   { 1, 0, 0, 1, 0, 0 }; // default
@@ -32,11 +37,11 @@ public class PDVisibleSignDesigner
      * @param page The page are you going to add visible signature
      * @throws IOException
      */
-//    public PDVisibleSignDesigner(String filename, InputStream jpegStream, int page)
-//            throws IOException
-//    {
-//        this(new FileInputStream(filename), jpegStream, page);
-//    }TODO
+    public PDVisibleSignDesigner(String filename, InputStream jpegStream, int page)
+            throws IOException
+    {
+        this(new FileInputStream(filename), jpegStream, page);
+    }
 
     /**
      * Constructor.
@@ -46,20 +51,20 @@ public class PDVisibleSignDesigner
      * @param page The page are you going to add visible signature
      * @throws IOException
      */
-//    public PDVisibleSignDesigner(InputStream documentStream, InputStream jpegStream, int page)
-//            throws IOException
-//    {
-//        // set visible singature image Input stream
-//        signatureImageStream(jpegStream);
-//
-//        // create PD document
-//        PDDocument document = PDDocument.load(documentStream);
-//
-//        // calculate height an width of document
-//        calculatePageSize(document, page);
-//
-//        document.close();
-//    }TODO
+    public PDVisibleSignDesigner(InputStream documentStream, InputStream jpegStream, int page)
+            throws IOException
+    {
+        // set visible singature image Input stream
+        signatureImageStream(jpegStream);
+
+        // create PD document
+        PDDocument document = PDDocument.load(documentStream);
+
+        // calculate height an width of document
+        calculatePageSize(document, page);
+
+        document.close();
+    }
 
     /**
      * Constructor.
@@ -69,11 +74,11 @@ public class PDVisibleSignDesigner
      * @param page
      * @throws IOException - If we can't read, flush, or can't close stream
      */
-//    public PDVisibleSignDesigner(PDDocument doc, InputStream jpegStream, int page) throws IOException
-//    {
-//        signatureImageStream(jpegStream);
-//        calculatePageSize(doc, page);
-//    }TODO
+    public PDVisibleSignDesigner(PDDocument doc, InputStream jpegStream, int page) throws IOException
+    {
+        signatureImageStream(jpegStream);
+        calculatePageSize(doc, page);
+    }
 
     /**
      * Each page of document can be different sizes.
@@ -106,11 +111,11 @@ public class PDVisibleSignDesigner
      * @return image Stream
      * @throws IOException
      */
-//    public PDVisibleSignDesigner signatureImage(String path) throws IOException
-//    {
-//        InputStream fin = new FileInputStream(path);
-//        return signatureImageStream(fin);
-//    }TODO
+    public PDVisibleSignDesigner signatureImage(String path) throws IOException
+    {
+        InputStream fin = new FileInputStream(path);
+        return signatureImageStream(fin);
+    }
 
     /**
      * zoom signature image with some percent.
@@ -262,10 +267,10 @@ public class PDVisibleSignDesigner
      * 
      * @return image Image
      */
-//    public BufferedImage getImage()
-//    {
-//        return image;
-//    }TODO
+    public Bitmap getImage()
+    {
+        return image;
+    }
 
     /**
      * 
@@ -273,14 +278,13 @@ public class PDVisibleSignDesigner
      * @return Visible Signature Configuration Object
      * @throws IOException If we can't read, flush, or close stream of image
      */
-//    private PDVisibleSignDesigner signatureImageStream(InputStream stream) throws IOException
-//    {
-//        ImageIO.setUseCache(false);
-//        image = ImageIO.read(stream);
-//        imageHeight = (float)image.getHeight();
-//        imageWidth = (float)image.getWidth();
-//        return this;
-//    }TODO
+    private PDVisibleSignDesigner signatureImageStream(InputStream stream) throws IOException
+    {
+        image = BitmapFactory.decodeStream(stream); 
+        imageHeight = (float)image.getHeight();
+        imageWidth = (float)image.getWidth();
+        return this;
+    }
 
     /**
      * 


### PR DESCRIPTION
This patch port the support of visual presentation of digital signature.

It uses Bitmap instead of BufferedImage.

Note that the transparent signature is not yet supported as the Bitmap's api seems do not support ALPHA_8 configuration needed to make the SMask transparent layer.